### PR TITLE
chore: update ESLint configuration for page objects and add concurren…

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main, master]
 
+concurrency:
+  group: playwright-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -84,7 +84,7 @@ export default tseslint.config(
   // Playwright 推奨ルール（テストファイルのみに適用）
   {
     ...playwright.configs["flat/recommended"],
-    files: ["tests/**/*.spec.ts"],
+    files: ["tests/**/*.spec.ts", "pages/**/*.ts"],
     rules: {
       ...playwright.configs["flat/recommended"].rules,
       "functional/no-return-void": "off", // テストは副作用必須

--- a/pages/login.page.ts
+++ b/pages/login.page.ts
@@ -19,14 +19,16 @@ export const getPasswordInput = (page: Readonly<Page>): Locator =>
 
 // ログインボタンを取得する
 export const getSubmitButton = (page: Readonly<Page>): Locator =>
+  // eslint-disable-next-line playwright/no-raw-locators
   page.locator("#login-button");
 
 // メールアドレスのエラーメッセージを取得する
 export const getEmailErrorMessage = (page: Readonly<Page>): Locator =>
+  // eslint-disable-next-line playwright/no-raw-locators
   page.locator("#email-message");
 
-// パスワードのエラーメッセージを取得する
 export const getPasswordErrorMessage = (page: Readonly<Page>): Locator =>
+  // eslint-disable-next-line playwright/no-raw-locators
   page.locator("#password-message");
 
 // メールアドレスとパスワードを引数で受け取り、ログインする


### PR DESCRIPTION
chore: CIの並列実行制御の追加と、POMへの静的解析ルールの適用
- playwright.yml: concurrency設定を追加し、同一PRへの連続プッシュ時に古いジョブを自動キャンセルしてCIリソース消費を最適化
- eslint.config.mts: 従来テストファイルのみ対象だったPlaywright推奨ルールを `pages/**/*.ts` (Page Object Model) にも適用し、ロケーター品質基準を強化
- login.page.ts: 外部サイトのDOM制約によりセマンティックロケーター（getByRole等）が使用できない箇所について、`page.locator()` を使用した上で `eslint-disable-next-line` で明示的に許容するよう修正wright workflow