### PR TITLE
feat: add GitHub Actions workflow to automatically fix linting and fo…

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -1,0 +1,42 @@
+name: Dependabot Auto-fix
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: write
+
+jobs:
+  autofix:
+    name: Auto-fix formatting and linting
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: pnpm/action-setup@v6
+        name: Install pnpm
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run format and lint fixes
+        run: |
+          pnpm lint:fix || true
+          pnpm format || true
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(deps): auto-fix linting and formatting issues"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
chore(deps): dependabotのPRに対する自動修復ワークフローの追加

## 目的
Dependabotの更新時に発生するLintエラーによるCI失敗を防ぎ、手作業での修正をなくすため。

## 変更内容
- `dependabot-autofix.yml` の新規追加
