### PR TITLE
ci: deploy-reportジョブの実行条件にキャンセル時のスキップを追加

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -124,7 +124,7 @@ jobs:
   deploy-report:
     name: Deploy Report
     needs: merge-reports
-    if: github.ref == 'refs/heads/main' && always()
+    if: github.ref == 'refs/heads/main' && always() && !cancelled()
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイメントレポートジョブの実行条件を改善しました。キャンセルされた実行中のレポート生成を防ぎ、本番ブランチでのみ実行するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->